### PR TITLE
Handle windows file paths from the .sln when running on posix systems.

### DIFF
--- a/src/DotNet.Consolidate.Tests/Services/PathUtilsTests.cs
+++ b/src/DotNet.Consolidate.Tests/Services/PathUtilsTests.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.IO;
+using DotNet.Consolidate.Services;
+using Xunit;
+
+namespace DotNet.Consolidate.Tests.Services
+{
+    public class PathUtilsTests
+    {
+        public static IEnumerable<object[]> PathTestData()
+        {
+            yield return new object[] { "a/posix/path", Path.Combine("a", "posix", "path") };
+            yield return new object[] { "a\\windows\\path", Path.Combine("a", "windows", "path") };
+            yield return new object[] { "a\\mixed/path", Path.Combine("a", "mixed", "path") };
+            yield return new object[] { "single", Path.Combine("single") };
+            yield return new object[] { "C:\\full\\windows\\path", Path.Combine("C:", "full", "windows", "path") };
+            yield return new object[] { string.Empty, string.Empty };
+            yield return new object[] { ".\\explicit\\relative", Path.Combine(".", "explicit", "relative") };
+            yield return new object[] { "/full/posix/path", Path.DirectorySeparatorChar + Path.Combine("full", "posix", "path") };
+            yield return new object[] { "\\windows\\posix\\path", Path.DirectorySeparatorChar + Path.Combine("windows", "posix", "path") };
+        }
+
+        [Theory]
+        [MemberData(nameof(PathTestData))]
+        public void GivenPathWithAnySeparator_WhenEnsureSystemSeparator_AssertReturnedPathIsCorrect(string input, string expected)
+        {
+            var actual = PathUtils.EnsureSystemSeparator(input);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/src/DotNet.Consolidate/Services/PathUtils.cs
+++ b/src/DotNet.Consolidate/Services/PathUtils.cs
@@ -1,0 +1,26 @@
+using System.IO;
+
+namespace DotNet.Consolidate.Services
+{
+    public static class PathUtils
+    {
+        /// <summary>
+        /// Converts the path to use the correct system path separator.
+        /// </summary>
+        /// <param name="path">A path using any path separator.</param>
+        /// <returns>The equivalent path using the <see cref="Path.DirectorySeparatorChar"/>.</returns>
+        public static string EnsureSystemSeparator(string path)
+        {
+            if (Path.DirectorySeparatorChar != '\\')
+            {
+                return path.Replace('\\', Path.DirectorySeparatorChar);
+            }
+            else if (Path.DirectorySeparatorChar != '/')
+            {
+                return path.Replace('/', Path.DirectorySeparatorChar);
+            }
+
+            return path;
+        }
+    }
+}

--- a/src/DotNet.Consolidate/Services/SolutionInfoProvider.cs
+++ b/src/DotNet.Consolidate/Services/SolutionInfoProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -39,6 +39,7 @@ namespace DotNet.Consolidate.Services
 
             try
             {
+                filePath = PathUtils.EnsureSystemSeparator(filePath);
                 var solution = SolutionParser.Parse(filePath);
 
                 var solutionDirectory = Path.GetDirectoryName(filePath);
@@ -56,7 +57,9 @@ namespace DotNet.Consolidate.Services
                         continue;
                     }
 
-                    var projectFilePath = Path.Combine(solutionDirectory, project.Path);
+                    // Solution files use the windows path separator '\' by default,
+                    // so we must convert to system path separator to work on posix systems.
+                    var projectFilePath = PathUtils.EnsureSystemSeparator(Path.Combine(solutionDirectory, project.Path));
                     var projectDirectory = Path.GetDirectoryName(projectFilePath);
                     if (projectDirectory == null)
                     {
@@ -65,7 +68,7 @@ namespace DotNet.Consolidate.Services
                         return solutionInfos;
                     }
 
-                    var packageConfigPath = Path.Combine(projectDirectory, "packages.config");
+                    var packageConfigPath = PathUtils.EnsureSystemSeparator(Path.Combine(projectDirectory, "packages.config"));
                     if (File.Exists(packageConfigPath))
                     {
                         var packages = _projectParser.ParsePackageConfig(packageConfigPath);


### PR DESCRIPTION
Visual Studio on windows uses backslash path separators in the solution file data. Currently this results in dotnet-consolidate not being able to find the .csproj files. This PR converts the path to ensure the use of forward slash when required.

There's no obvious built in way to handle incorrect path separators so I'm using String.Replace.