### PR TITLE
Feature/support directory build props

### DIFF
--- a/src/DotNet.Consolidate.Tests/DotNet.Consolidate.Tests.csproj
+++ b/src/DotNet.Consolidate.Tests/DotNet.Consolidate.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="TestData\Directory.build.props" />
     <None Remove="TestData\packages.config" />
   </ItemGroup>
 
@@ -24,13 +25,50 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="TestData\Directory.build.props" />
     <EmbeddedResource Include="TestData\PackageReference.csproj" />
     <EmbeddedResource Include="TestData\NetCore.csproj" />
     <EmbeddedResource Include="TestData\packages.config" />
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="TestData\TestSolution\src\ProjectA\ProjectA.csproj">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="TestData\TestSolution\src\ProjectB\ProjectB.csproj">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="TestData\TestSolution\tests\ProjectA.Tests\ProjectA.Tests.csproj">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="TestData\TestSolution\tests\ProjectB.Tests\ProjectB.Tests.csproj">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="TestData\TestSolution\TestSolution.sln">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\DotNet.Consolidate\DotNet.Consolidate.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="TestData\TestSolution\Directory.build.props">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TestData\TestSolution\tests\Directory.build.props">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/DotNet.Consolidate.Tests/Services/PackagesAnalyzerTests.cs
+++ b/src/DotNet.Consolidate.Tests/Services/PackagesAnalyzerTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 using DotNet.Consolidate.Models;
 using DotNet.Consolidate.Services;
@@ -14,10 +14,10 @@ public class PackagesAnalyzerTests
     {
         // This case may happen when you have mixed project types in your solution
         var analyzer = new PackagesAnalyzer();
-        var info = new ProjectInfo("Test", new List<NuGetPackageInfo>
+        var info = new ProjectInfo("Test", "Test", new List<NuGetPackageInfo>
         {
-            new ("myid", new Version("1.0.1")),
-            new ("myid", new Version("1.0.1.0"))
+            new ("myid", new Version("1.0.1"), NuGetPackageReferenceType.Direct),
+            new ("myid", new Version("1.0.1.0"), NuGetPackageReferenceType.Direct)
         });
         var projectInfos = new List<ProjectInfo> { info };
         var options = new Options(new List<string>(), new List<string>(), new List<string>());
@@ -30,10 +30,10 @@ public class PackagesAnalyzerTests
     public void Packages_with_different_versions_are_not_consolidated()
     {
         var analyzer = new PackagesAnalyzer();
-        var info = new ProjectInfo("Test", new List<NuGetPackageInfo>()
+        var info = new ProjectInfo("Test", "Test", new List<NuGetPackageInfo>()
         {
-            new ("myid", new Version("1.1.0")),
-            new ("myid", new Version("1.0.1.0"))
+            new ("myid", new Version("1.1.0"), NuGetPackageReferenceType.Direct),
+            new ("myid", new Version("1.0.1.0"), NuGetPackageReferenceType.Direct)
         });
         var projectInfos = new List<ProjectInfo> { info };
         var options = new Options(new List<string>(), new List<string>(), new List<string>());

--- a/src/DotNet.Consolidate.Tests/Services/ProjectParserTests.cs
+++ b/src/DotNet.Consolidate.Tests/Services/ProjectParserTests.cs
@@ -1,4 +1,4 @@
-﻿using DotNet.Consolidate.Services;
+using DotNet.Consolidate.Services;
 using DotNet.Consolidate.Tests.Helpers;
 using Xunit;
 
@@ -37,6 +37,17 @@ namespace DotNet.Consolidate.Tests.Services
             var nuGetPackages = parser.ParsePackageConfigContent(packagesConfig);
 
             Assert.Equal(2, nuGetPackages.Count);
+        }
+
+        [Fact]
+        public void Directory_Build_props_reference_project_parsed_correctly()
+        {
+            var parser = new ProjectParser(new Logger());
+            var projectFile = FileHelper.ReadResource("Directory.build.props");
+
+            var nuGetPackages = parser.ParseProjectContent(projectFile);
+
+            Assert.Equal(7, nuGetPackages.Count);
         }
 
         private static ProjectParser GetParser()

--- a/src/DotNet.Consolidate.Tests/Services/SolutionParserTests.cs
+++ b/src/DotNet.Consolidate.Tests/Services/SolutionParserTests.cs
@@ -24,9 +24,12 @@ namespace DotNet.Consolidate.Tests.Services
             var solutionInfoProvider = new SolutionInfoProvider(projectParser, new Logger(), true);
 
             var solutions = new[] { TestSolutionFileName };
+
+            // Act
             var solution = solutionInfoProvider.GetSolutionsInfo(solutions)
                 .FirstOrDefault();
 
+            // Assert
             Assert.NotNull(solution);
             Assert.Equal(2, solution.DirectoryBuildPropsInfos.Count);
         }
@@ -38,9 +41,12 @@ namespace DotNet.Consolidate.Tests.Services
             var solutionInfoProvider = new SolutionInfoProvider(projectParser, new Logger(), false);
 
             var solutions = new[] { TestSolutionFileName };
+
+            // Act
             var solution = solutionInfoProvider.GetSolutionsInfo(solutions)
                 .FirstOrDefault();
 
+            // Assert
             Assert.NotNull(solution);
             Assert.Equal(0, solution.DirectoryBuildPropsInfos.Count);
         }
@@ -52,6 +58,8 @@ namespace DotNet.Consolidate.Tests.Services
             var solutionInfoProvider = new SolutionInfoProvider(projectParser, new Logger(), true);
 
             var solutions = new[] { TestSolutionFileName };
+
+            // Act
             var solution = solutionInfoProvider.GetSolutionsInfo(solutions)
                 .FirstOrDefault();
 
@@ -60,6 +68,7 @@ namespace DotNet.Consolidate.Tests.Services
             var projectATests = solution.ProjectInfos.FirstOrDefault(p => p.ProjectName.Equals("ProjectA.Tests"));
             var projectBTests = solution.ProjectInfos.FirstOrDefault(p => p.ProjectName.Equals("ProjectB.Tests"));
 
+            // Assert
             Assert.NotNull(projectA);
             Assert.Equal(2, projectA.Packages.Count);
             Assert.Equal(0, projectA.Packages.Count(p => p.PackageReferenceType == NuGetPackageReferenceType.Direct));
@@ -81,44 +90,43 @@ namespace DotNet.Consolidate.Tests.Services
             Assert.Equal(7, projectBTests.Packages.Count(p => p.PackageReferenceType == NuGetPackageReferenceType.Inherited));
         }
 
-#if SHIT
         [Fact]
-        public void Net_core_reference_project_parsed_correctly()
+        public void Solution_with_DirectoryBuildProps_when_not_allowed_to_read_them_determines_project_references_correctly()
         {
-            var parser = new ProjectParser(new Logger());
-            var projectFile = FileHelper.ReadResource("NetCore.csproj");
+            var projectParser = new ProjectParser(new Logger());
+            var solutionInfoProvider = new SolutionInfoProvider(projectParser, new Logger(), false);
 
-            var nuGetPackages = parser.ParseProjectContent(projectFile);
+            var solutions = new[] { TestSolutionFileName };
 
-            Assert.Equal(3, nuGetPackages.Count);
+            // Act
+            var solution = solutionInfoProvider.GetSolutionsInfo(solutions)
+                .FirstOrDefault();
+
+            var projectA = solution.ProjectInfos.FirstOrDefault(p => p.ProjectName.Equals("ProjectA"));
+            var projectB = solution.ProjectInfos.FirstOrDefault(p => p.ProjectName.Equals("ProjectB"));
+            var projectATests = solution.ProjectInfos.FirstOrDefault(p => p.ProjectName.Equals("ProjectA.Tests"));
+            var projectBTests = solution.ProjectInfos.FirstOrDefault(p => p.ProjectName.Equals("ProjectB.Tests"));
+
+            // Assert
+            Assert.NotNull(projectA);
+            Assert.Equal(0, projectA.Packages.Count);
+            Assert.Equal(0, projectA.Packages.Count(p => p.PackageReferenceType == NuGetPackageReferenceType.Direct));
+            Assert.Equal(0, projectA.Packages.Count(p => p.PackageReferenceType == NuGetPackageReferenceType.Inherited));
+
+            Assert.NotNull(projectB);
+            Assert.Equal(1, projectB.Packages.Count);
+            Assert.Equal(1, projectB.Packages.Count(p => p.PackageReferenceType == NuGetPackageReferenceType.Direct));
+            Assert.Equal(0, projectB.Packages.Count(p => p.PackageReferenceType == NuGetPackageReferenceType.Inherited));
+
+            Assert.NotNull(projectATests);
+            Assert.Equal(0, projectATests.Packages.Count);
+            Assert.Equal(0, projectATests.Packages.Count(p => p.PackageReferenceType == NuGetPackageReferenceType.Direct));
+            Assert.Equal(0, projectATests.Packages.Count(p => p.PackageReferenceType == NuGetPackageReferenceType.Inherited));
+
+            Assert.NotNull(projectBTests);
+            Assert.Equal(0, projectBTests.Packages.Count);
+            Assert.Equal(0, projectBTests.Packages.Count(p => p.PackageReferenceType == NuGetPackageReferenceType.Direct));
+            Assert.Equal(0, projectBTests.Packages.Count(p => p.PackageReferenceType == NuGetPackageReferenceType.Inherited));
         }
-
-        [Fact]
-        public void Packages_config_parsed_correctly()
-        {
-            var parser = GetParser();
-            var packagesConfig = FileHelper.ReadResource("packages.config");
-
-            var nuGetPackages = parser.ParsePackageConfigContent(packagesConfig);
-
-            Assert.Equal(2, nuGetPackages.Count);
-        }
-
-        [Fact]
-        public void Directory_Build_props_reference_project_parsed_correctly()
-        {
-            var parser = new ProjectParser(new Logger());
-            var projectFile = FileHelper.ReadResource("Directory.build.props");
-
-            var nuGetPackages = parser.ParseProjectContent(projectFile);
-
-            Assert.Equal(7, nuGetPackages.Count);
-        }
-
-        private static ProjectParser GetParser()
-        {
-            return new ProjectParser(new Logger());
-        }
-#endif
     }
 }

--- a/src/DotNet.Consolidate.Tests/Services/SolutionParserTests.cs
+++ b/src/DotNet.Consolidate.Tests/Services/SolutionParserTests.cs
@@ -1,0 +1,124 @@
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+using DotNet.Consolidate.Models;
+using DotNet.Consolidate.Services;
+
+using Xunit;
+
+using ProjectParser = DotNet.Consolidate.Services.ProjectParser;
+
+namespace DotNet.Consolidate.Tests.Services
+{
+    public class SolutionParserTests
+    {
+        private static string TestSolutionDirectoryName => Path.Join(new FileInfo(Assembly.GetExecutingAssembly().Location).DirectoryName, "TestData", "TestSolution");
+
+        private static string TestSolutionFileName => Path.Join(TestSolutionDirectoryName, "TestSolution.sln");
+
+        [Fact]
+        public void Solution_with_DirectoryBuildProps_parsed_correctly_when_allowed_to_read_them()
+        {
+            var projectParser = new ProjectParser(new Logger());
+            var solutionInfoProvider = new SolutionInfoProvider(projectParser, new Logger(), true);
+
+            var solutions = new[] { TestSolutionFileName };
+            var solution = solutionInfoProvider.GetSolutionsInfo(solutions)
+                .FirstOrDefault();
+
+            Assert.NotNull(solution);
+            Assert.Equal(2, solution.DirectoryBuildPropsInfos.Count);
+        }
+
+        [Fact]
+        public void Solution_with_DirectoryBuildProps_parsed_correctly_when_not_allowed_to_read_them()
+        {
+            var projectParser = new ProjectParser(new Logger());
+            var solutionInfoProvider = new SolutionInfoProvider(projectParser, new Logger(), false);
+
+            var solutions = new[] { TestSolutionFileName };
+            var solution = solutionInfoProvider.GetSolutionsInfo(solutions)
+                .FirstOrDefault();
+
+            Assert.NotNull(solution);
+            Assert.Equal(0, solution.DirectoryBuildPropsInfos.Count);
+        }
+
+        [Fact]
+        public void Solution_with_DirectoryBuildProps_when_allowed_to_read_them_determines_project_references_correctly()
+        {
+            var projectParser = new ProjectParser(new Logger());
+            var solutionInfoProvider = new SolutionInfoProvider(projectParser, new Logger(), true);
+
+            var solutions = new[] { TestSolutionFileName };
+            var solution = solutionInfoProvider.GetSolutionsInfo(solutions)
+                .FirstOrDefault();
+
+            var projectA = solution.ProjectInfos.FirstOrDefault(p => p.ProjectName.Equals("ProjectA"));
+            var projectB = solution.ProjectInfos.FirstOrDefault(p => p.ProjectName.Equals("ProjectB"));
+            var projectATests = solution.ProjectInfos.FirstOrDefault(p => p.ProjectName.Equals("ProjectA.Tests"));
+            var projectBTests = solution.ProjectInfos.FirstOrDefault(p => p.ProjectName.Equals("ProjectB.Tests"));
+
+            Assert.NotNull(projectA);
+            Assert.Equal(2, projectA.Packages.Count);
+            Assert.Equal(0, projectA.Packages.Count(p => p.PackageReferenceType == NuGetPackageReferenceType.Direct));
+            Assert.Equal(2, projectA.Packages.Count(p => p.PackageReferenceType == NuGetPackageReferenceType.Inherited));
+
+            Assert.NotNull(projectB);
+            Assert.Equal(3, projectB.Packages.Count);
+            Assert.Equal(1, projectB.Packages.Count(p => p.PackageReferenceType == NuGetPackageReferenceType.Direct));
+            Assert.Equal(2, projectB.Packages.Count(p => p.PackageReferenceType == NuGetPackageReferenceType.Inherited));
+
+            Assert.NotNull(projectATests);
+            Assert.Equal(7, projectATests.Packages.Count);
+            Assert.Equal(0, projectATests.Packages.Count(p => p.PackageReferenceType == NuGetPackageReferenceType.Direct));
+            Assert.Equal(7, projectATests.Packages.Count(p => p.PackageReferenceType == NuGetPackageReferenceType.Inherited));
+
+            Assert.NotNull(projectBTests);
+            Assert.Equal(7, projectBTests.Packages.Count);
+            Assert.Equal(0, projectBTests.Packages.Count(p => p.PackageReferenceType == NuGetPackageReferenceType.Direct));
+            Assert.Equal(7, projectBTests.Packages.Count(p => p.PackageReferenceType == NuGetPackageReferenceType.Inherited));
+        }
+
+#if SHIT
+        [Fact]
+        public void Net_core_reference_project_parsed_correctly()
+        {
+            var parser = new ProjectParser(new Logger());
+            var projectFile = FileHelper.ReadResource("NetCore.csproj");
+
+            var nuGetPackages = parser.ParseProjectContent(projectFile);
+
+            Assert.Equal(3, nuGetPackages.Count);
+        }
+
+        [Fact]
+        public void Packages_config_parsed_correctly()
+        {
+            var parser = GetParser();
+            var packagesConfig = FileHelper.ReadResource("packages.config");
+
+            var nuGetPackages = parser.ParsePackageConfigContent(packagesConfig);
+
+            Assert.Equal(2, nuGetPackages.Count);
+        }
+
+        [Fact]
+        public void Directory_Build_props_reference_project_parsed_correctly()
+        {
+            var parser = new ProjectParser(new Logger());
+            var projectFile = FileHelper.ReadResource("Directory.build.props");
+
+            var nuGetPackages = parser.ParseProjectContent(projectFile);
+
+            Assert.Equal(7, nuGetPackages.Count);
+        }
+
+        private static ProjectParser GetParser()
+        {
+            return new ProjectParser(new Logger());
+        }
+#endif
+    }
+}

--- a/src/DotNet.Consolidate.Tests/TestData/Directory.build.props
+++ b/src/DotNet.Consolidate.Tests/TestData/Directory.build.props
@@ -1,0 +1,20 @@
+<Project>
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.17.0" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Moq" Version="4.18.1" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+</Project>

--- a/src/DotNet.Consolidate.Tests/TestData/TestSolution/Directory.build.props
+++ b/src/DotNet.Consolidate.Tests/TestData/TestSolution/Directory.build.props
@@ -1,0 +1,15 @@
+<Project>
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <Platforms>x64</Platforms>
+        <LangVersion>10.0</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>disable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="CommandLineParser" Version="2.7.82" />
+        <PackageReference Include="Serilog" Version="3.0.1" />
+    </ItemGroup>
+
+</Project>

--- a/src/DotNet.Consolidate.Tests/TestData/TestSolution/TestSolution.sln
+++ b/src/DotNet.Consolidate.Tests/TestData/TestSolution/TestSolution.sln
@@ -1,0 +1,61 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33723.286
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{91927A48-FE66-4083-8F03-EEAFA974C86C}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{5CD86CD0-0B02-47B4-9633-5C65875733FC}"
+	ProjectSection(SolutionItems) = preProject
+		tests\Directory.build.props = tests\Directory.build.props
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProjectA", "src\ProjectA\ProjectA.csproj", "{B2641D3B-1DE4-462D-BBBF-6874EFC3B7D0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProjectB", "src\ProjectB\ProjectB.csproj", "{76DB371A-4871-417B-8CD5-38F4250050BF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProjectA.Tests", "tests\ProjectA.Tests\ProjectA.Tests.csproj", "{01777C80-CDE9-49C7-8FAD-590CAF9E8E23}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProjectB.Tests", "tests\ProjectB.Tests\ProjectB.Tests.csproj", "{FA79411B-61D5-40E5-8E5C-B832E5E57BBD}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{CF9FA02D-AA0B-4A3A-8CF0-F1124FA43B43}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.build.props = Directory.build.props
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B2641D3B-1DE4-462D-BBBF-6874EFC3B7D0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B2641D3B-1DE4-462D-BBBF-6874EFC3B7D0}.Debug|x64.Build.0 = Debug|Any CPU
+		{B2641D3B-1DE4-462D-BBBF-6874EFC3B7D0}.Release|x64.ActiveCfg = Release|Any CPU
+		{B2641D3B-1DE4-462D-BBBF-6874EFC3B7D0}.Release|x64.Build.0 = Release|Any CPU
+		{76DB371A-4871-417B-8CD5-38F4250050BF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{76DB371A-4871-417B-8CD5-38F4250050BF}.Debug|x64.Build.0 = Debug|Any CPU
+		{76DB371A-4871-417B-8CD5-38F4250050BF}.Release|x64.ActiveCfg = Release|Any CPU
+		{76DB371A-4871-417B-8CD5-38F4250050BF}.Release|x64.Build.0 = Release|Any CPU
+		{01777C80-CDE9-49C7-8FAD-590CAF9E8E23}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{01777C80-CDE9-49C7-8FAD-590CAF9E8E23}.Debug|x64.Build.0 = Debug|Any CPU
+		{01777C80-CDE9-49C7-8FAD-590CAF9E8E23}.Release|x64.ActiveCfg = Release|Any CPU
+		{01777C80-CDE9-49C7-8FAD-590CAF9E8E23}.Release|x64.Build.0 = Release|Any CPU
+		{FA79411B-61D5-40E5-8E5C-B832E5E57BBD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FA79411B-61D5-40E5-8E5C-B832E5E57BBD}.Debug|x64.Build.0 = Debug|Any CPU
+		{FA79411B-61D5-40E5-8E5C-B832E5E57BBD}.Release|x64.ActiveCfg = Release|Any CPU
+		{FA79411B-61D5-40E5-8E5C-B832E5E57BBD}.Release|x64.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{B2641D3B-1DE4-462D-BBBF-6874EFC3B7D0} = {91927A48-FE66-4083-8F03-EEAFA974C86C}
+		{76DB371A-4871-417B-8CD5-38F4250050BF} = {91927A48-FE66-4083-8F03-EEAFA974C86C}
+		{01777C80-CDE9-49C7-8FAD-590CAF9E8E23} = {5CD86CD0-0B02-47B4-9633-5C65875733FC}
+		{FA79411B-61D5-40E5-8E5C-B832E5E57BBD} = {5CD86CD0-0B02-47B4-9633-5C65875733FC}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {40DE902E-DB50-4D7C-A519-E6DC61D0059A}
+	EndGlobalSection
+EndGlobal

--- a/src/DotNet.Consolidate.Tests/TestData/TestSolution/src/ProjectA/ProjectA.csproj
+++ b/src/DotNet.Consolidate.Tests/TestData/TestSolution/src/ProjectA/ProjectA.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Platforms>x64;x64</Platforms>
+  </PropertyGroup>
+
+</Project>

--- a/src/DotNet.Consolidate.Tests/TestData/TestSolution/src/ProjectB/ProjectB.csproj
+++ b/src/DotNet.Consolidate.Tests/TestData/TestSolution/src/ProjectB/ProjectB.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="7.0.3" />
+  </ItemGroup>
+
+</Project>

--- a/src/DotNet.Consolidate.Tests/TestData/TestSolution/tests/Directory.build.props
+++ b/src/DotNet.Consolidate.Tests/TestData/TestSolution/tests/Directory.build.props
@@ -1,0 +1,22 @@
+<Project>
+
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="AutoFixture" Version="4.17.0" />
+        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+        <PackageReference Include="Moq" Version="4.18.1" />
+        <PackageReference Include="NUnit" Version="3.13.3" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/DotNet.Consolidate.Tests/TestData/TestSolution/tests/ProjectA.Tests/ProjectA.Tests.csproj
+++ b/src/DotNet.Consolidate.Tests/TestData/TestSolution/tests/ProjectA.Tests/ProjectA.Tests.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+</Project>

--- a/src/DotNet.Consolidate.Tests/TestData/TestSolution/tests/ProjectB.Tests/ProjectB.Tests.csproj
+++ b/src/DotNet.Consolidate.Tests/TestData/TestSolution/tests/ProjectB.Tests/ProjectB.Tests.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+</Project>

--- a/src/DotNet.Consolidate/Models/DirectoryBuildPropsInfo.cs
+++ b/src/DotNet.Consolidate/Models/DirectoryBuildPropsInfo.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace DotNet.Consolidate.Models
+{
+    public class DirectoryBuildPropsInfo
+    {
+        public DirectoryBuildPropsInfo(string fileName, string directoryName, ICollection<NuGetPackageInfo> packages)
+        {
+            FileName = fileName;
+            DirectoryName = directoryName;
+            Packages = packages;
+        }
+
+        public ICollection<NuGetPackageInfo> Packages { get; }
+
+        public string FileName { get; }
+
+        public string DirectoryName { get; }
+    }
+}

--- a/src/DotNet.Consolidate/Models/NuGetPackageInfo.cs
+++ b/src/DotNet.Consolidate/Models/NuGetPackageInfo.cs
@@ -1,15 +1,18 @@
-﻿namespace DotNet.Consolidate.Models
+namespace DotNet.Consolidate.Models
 {
     public class NuGetPackageInfo
     {
-        public NuGetPackageInfo(string id, Version version)
+        public NuGetPackageInfo(string id, Version version, NuGetPackageReferenceType packageReferenceType)
         {
             Id = id;
             Version = version;
+            PackageReferenceType = packageReferenceType;
         }
 
         public string Id { get; }
 
         public Version Version { get; }
+
+        public NuGetPackageReferenceType PackageReferenceType { get; }
     }
 }

--- a/src/DotNet.Consolidate/Models/NuGetPackageReferenceType.cs
+++ b/src/DotNet.Consolidate/Models/NuGetPackageReferenceType.cs
@@ -1,0 +1,8 @@
+namespace DotNet.Consolidate.Models
+{
+    public enum NuGetPackageReferenceType
+    {
+        Direct,
+        Inherited
+    }
+}

--- a/src/DotNet.Consolidate/Models/Options.cs
+++ b/src/DotNet.Consolidate/Models/Options.cs
@@ -21,5 +21,11 @@ namespace DotNet.Consolidate.Models
 
         [Option('s', "solutions", Required = false, HelpText = "Target solutions for checking. If not specified, all solutions in the working directory will be analyzed.")]
         public ICollection<string>? Solutions { get; }
+
+        [Option('d', "directoryBuildProps", Required = false, Default = true, HelpText = "Take Directory.Build.props files into account")]
+        public bool ReadDirectoryBuildProps { get; set; }
+
+        [Option('o', "reportOverridenDirectoryBuildProps", Required = false, Default = true, HelpText = "Report when csproj overrides a Directory.Build.props")]
+        public bool ReportOverridenDirectoryBuildProps { get; set; }
     }
 }

--- a/src/DotNet.Consolidate/Models/ProjectInfo.cs
+++ b/src/DotNet.Consolidate/Models/ProjectInfo.cs
@@ -1,17 +1,20 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace DotNet.Consolidate.Models
 {
     public class ProjectInfo
     {
-        public ProjectInfo(string projectName, ICollection<NuGetPackageInfo> packages)
+        public ProjectInfo(string projectName, string projectDirectory, ICollection<NuGetPackageInfo> packages)
         {
             ProjectName = projectName;
+            ProjectDirectory = projectDirectory;
             Packages = packages;
         }
 
         public ICollection<NuGetPackageInfo> Packages { get; }
 
         public string ProjectName { get; }
+
+        public string ProjectDirectory { get; }
     }
 }

--- a/src/DotNet.Consolidate/Models/SolutionInfo.cs
+++ b/src/DotNet.Consolidate/Models/SolutionInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 
 using DotNet.Consolidate.Constants;
@@ -9,14 +9,17 @@ namespace DotNet.Consolidate.Models
 {
     public class SolutionInfo
     {
-        public SolutionInfo(string solutionFile, ISolution? solution, ICollection<ProjectInfo> projectInfos)
+        public SolutionInfo(string solutionFile, ISolution? solution, ICollection<ProjectInfo> projectInfos, ICollection<DirectoryBuildPropsInfo> directoryBuildPropsInfos)
         {
             SolutionFile = solutionFile;
             Solution = solution;
             ProjectInfos = projectInfos;
+            DirectoryBuildPropsInfos = directoryBuildPropsInfos;
         }
 
         public ICollection<ProjectInfo> ProjectInfos { get; }
+
+        public ICollection<DirectoryBuildPropsInfo> DirectoryBuildPropsInfos { get; }
 
         public string SolutionFile { get; }
 

--- a/src/DotNet.Consolidate/Program.cs
+++ b/src/DotNet.Consolidate/Program.cs
@@ -40,7 +40,7 @@ namespace DotNet.Consolidate
                 return;
             }
 
-            var solutionInfoProvider = new SolutionInfoProvider(new ProjectParser(logger), logger);
+            var solutionInfoProvider = new SolutionInfoProvider(new ProjectParser(logger), logger, options.ReadDirectoryBuildProps);
 
             ICollection<string> solutions;
             if (options.Solutions?.Any() == true)

--- a/src/DotNet.Consolidate/Properties/launchSettings.json
+++ b/src/DotNet.Consolidate/Properties/launchSettings.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "DotNet.Consolidate": {
+      "commandName": "Project"
+    }
+  }
+}

--- a/src/DotNet.Consolidate/Services/ProjectParser.cs
+++ b/src/DotNet.Consolidate/Services/ProjectParser.cs
@@ -55,7 +55,7 @@ namespace DotNet.Consolidate.Services
                     continue;
                 }
 
-                packageInfos.Add(new NuGetPackageInfo(id.Value, new Version(version.Value)));
+                packageInfos.Add(new NuGetPackageInfo(id.Value, new Version(version.Value), NuGetPackageReferenceType.Direct));
             }
 
             return packageInfos;
@@ -99,7 +99,7 @@ namespace DotNet.Consolidate.Services
                     continue;
                 }
 
-                packageInfos.Add(new NuGetPackageInfo(id.Value, new Version(version)));
+                packageInfos.Add(new NuGetPackageInfo(id.Value, new Version(version), NuGetPackageReferenceType.Direct));
             }
 
             return packageInfos;

--- a/src/DotNet.Consolidate/Services/SolutionInfoProvider.cs
+++ b/src/DotNet.Consolidate/Services/SolutionInfoProvider.cs
@@ -50,6 +50,9 @@ namespace DotNet.Consolidate.Services
             return solutionInfos;
         }
 
+        /// <remarks>
+        /// NOTE: This does not support chained Directory.Build.props (Import directive)
+        /// </remarks>
         private static void ApplyInheritedPackages(ICollection<ProjectInfo> projectsInfo, ICollection<DirectoryBuildPropsInfo> directoryBuildPropsInfos)
         {
             if (!projectsInfo.Any())


### PR DESCRIPTION
Added support for Directory.Build.props files, which can override all Project files in its own or sub directories.

It doesn't support chained Directory.Build.props files, as that would require parsing of the Import directive in project files. I thought I'd offer this up first and maybe look at that later

Thoughts ?