### PR TITLE
Another negative test for version exclude regex

### DIFF
--- a/src/DotNet.Consolidate.Tests/Services/PackagesAnalyzerTests.cs
+++ b/src/DotNet.Consolidate.Tests/Services/PackagesAnalyzerTests.cs
@@ -45,6 +45,7 @@ public class PackagesAnalyzerTests
     [Theory]
     [InlineData(".*-alpha$", true)]
     [InlineData(".*-beta$", false)]
+    [InlineData("", false)]
     public void Packages_version_exclude_regex_correctly_matches(string excludedPackageVersionsRegex, bool shouldMatch)
     {
         var analyzer = new PackagesAnalyzer();


### PR DESCRIPTION
I just realized that I missed the obvious case in the unit test: when no pattern is configured.