### PR TITLE
add .NET 9 target

### DIFF
--- a/src/DotNet.Consolidate/DotNet.Consolidate.csproj
+++ b/src/DotNet.Consolidate/DotNet.Consolidate.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />


### PR DESCRIPTION
See https://github.com/olsh/dotnet-consolidate/issues/68

Build and tests still on .NET `8.0`, since it's still supported.

@olsh to discuss:

- Remove unsupported .NET targets `6.0` and `7.0`?
- Bump version to `4.3.0`?